### PR TITLE
Fixing class name for application log statements

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,10 +5,10 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="controllers" level="${logger.application:-INFO}"/>
-    <logger name="services" level="${logger.application:-INFO}"/>
-    <logger name="models" level="${logger.application:-INFO}"/>
-    <logger name="repositories" level="${logger.application:-INFO}"/>
+    <logger name="uk.gov.hmrc.trustsstore.controllers" level="${logger.application:-INFO}"/>
+    <logger name="uk.gov.hmrc.trustsstore.services" level="${logger.application:-INFO}"/>
+    <logger name="uk.gov.hmrc.trustsstore.models" level="${logger.application:-INFO}"/>
+    <logger name="uk.gov.hmrc.trustsstore.repositories" level="${logger.application:-INFO}"/>
 
     <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -45,10 +45,10 @@
 
     <logger name="com.google.inject" level="WARN"/>
 
-    <logger name="controllers" level="INFO"/>
-    <logger name="services" level="INFO"/>
-    <logger name="models" level="INFO"/>
-    <logger name="repositories" level="INFO"/>
+    <logger name="uk.gov.hmrc.trustsstore.controllers" level="INFO"/>
+    <logger name="uk.gov.hmrc.trustsstore.services" level="INFO"/>
+    <logger name="uk.gov.hmrc.trustsstore.models" level="INFO"/>
+    <logger name="uk.gov.hmrc.trustsstore.repositories" level="INFO"/>
 
     <root level="WARN">
         <appender-ref ref="FILE"/>


### PR DESCRIPTION
- Package structure meant that the uk.gov WARN configuration took precedence and was not overridden due to no reference in app-config-X for logger.uk.gov

The packages are as follows: `uk.gov.hmrc.truststore.controllers`.