### PR TITLE
TRUS-4036: Set assets journey to in progress when no assets remaining

### DIFF
--- a/app/controllers/MaintainTaskListController.scala
+++ b/app/controllers/MaintainTaskListController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import controllers.actions.IdentifierAction
-import models.Operation.Complete
+import models.Operation.{Complete, Reset}
 import models.Task
 import models.maintain.Tasks
 import play.api.libs.json._
@@ -101,8 +101,8 @@ class MaintainTaskListController @Inject()(
 			service.modifyTask(request.internalId, identifier, Task.OtherIndividuals, Complete).map(Ok(_))
 	}
 
-//	def resetTrustDetails(identifier: String): Action[AnyContent] = authAction.async {
-//		implicit request =>
-//
-//	}
+	def resetAssets(identifier: String): Action[AnyContent] = authAction.async {
+		implicit request =>
+			service.modifyTask(request.internalId, identifier, Task.Assets, Reset).map(Ok(_))
+	}
 }

--- a/app/controllers/MaintainTaskListController.scala
+++ b/app/controllers/MaintainTaskListController.scala
@@ -17,7 +17,9 @@
 package controllers
 
 import controllers.actions.IdentifierAction
-import models.maintain.Task
+import models.Operation.Complete
+import models.Task
+import models.maintain.Tasks
 import play.api.libs.json._
 import play.api.mvc._
 import services.TasksService
@@ -26,15 +28,7 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait UpdateOperation
-case object UpdateTrustDetails extends UpdateOperation
-case object UpdateAssets extends UpdateOperation
-case object UpdateTaxLiability extends UpdateOperation
-case object UpdateTrustees extends UpdateOperation
-case object UpdateBeneficiaries extends UpdateOperation
-case object UpdateSettlors extends UpdateOperation
-case object UpdateProtectors extends UpdateOperation
-case object UpdateOtherIndividuals extends UpdateOperation
+
 
 @Singleton()
 class MaintainTaskListController @Inject()(
@@ -53,7 +47,7 @@ class MaintainTaskListController @Inject()(
 
 	def set(identifier: String): Action[JsValue] = authAction.async(parse.json) {
 		request =>
-			request.body.validate[Task] match {
+			request.body.validate[Tasks] match {
 				case JsSuccess(tasks, _) =>
 					service.set(request.internalId, identifier, tasks).map {
 						updated => Ok(Json.toJson(updated))
@@ -67,61 +61,48 @@ class MaintainTaskListController @Inject()(
 			service.reset(request.internalId, identifier).map(_ => Ok)
 	}
 
-	private def updateTask(internalId: String, identifier: String, update: UpdateOperation): Future[Result] = for {
-		tasks <- service.get(internalId, identifier)
-		updatedTasks <- Future.successful {
-			update match {
-				case UpdateTrustDetails => tasks.copy(trustDetails = true)
-				case UpdateAssets => tasks.copy(assets = true)
-				case UpdateTaxLiability => tasks.copy(taxLiability = true)
-				case UpdateTrustees => tasks.copy(trustees = true)
-				case UpdateBeneficiaries => tasks.copy(beneficiaries = true)
-				case UpdateProtectors => tasks.copy(protectors = true)
-				case UpdateSettlors => tasks.copy(settlors = true)
-				case UpdateOtherIndividuals => tasks.copy(other = true)
-			}
-		}
-		savedTasks <- service.set(internalId, identifier, updatedTasks)
-	} yield {
-		Ok(Json.toJson(savedTasks))
-	}
-
 	def completeTrustDetails(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateTrustDetails)
+			service.modifyTask(request.internalId, identifier, Task.TrustDetails, Complete).map(Ok(_))
 	}
 
 	def completeAssets(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateAssets)
+			service.modifyTask(request.internalId, identifier, Task.Assets, Complete).map(Ok(_))
 	}
 
 	def completeTaxLiability(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateTaxLiability)
+			service.modifyTask(request.internalId, identifier, Task.TaxLiability, Complete).map(Ok(_))
 	}
+
 	def completeTrustees(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateTrustees)
+			service.modifyTask(request.internalId, identifier, Task.Trustees, Complete).map(Ok(_))
 	}
 
 	def completeBeneficiaries(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateBeneficiaries)
+			service.modifyTask(request.internalId, identifier, Task.Beneficiaries, Complete).map(Ok(_))
 	}
 
 	def completeSettlors(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateSettlors)
+			service.modifyTask(request.internalId, identifier, Task.Settlors, Complete).map(Ok(_))
 	}
 
 	def completeProtectors(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateProtectors)
+			service.modifyTask(request.internalId, identifier, Task.Protectors, Complete).map(Ok(_))
 	}
 
 	def completeOtherIndividuals(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			updateTask(request.internalId, identifier, UpdateOtherIndividuals)
+			service.modifyTask(request.internalId, identifier, Task.OtherIndividuals, Complete).map(Ok(_))
 	}
+
+//	def resetTrustDetails(identifier: String): Action[AnyContent] = authAction.async {
+//		implicit request =>
+//
+//	}
 }

--- a/app/controllers/MaintainTaskListController.scala
+++ b/app/controllers/MaintainTaskListController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import controllers.actions.IdentifierAction
-import models.Operation.{Complete, Reset}
+import models.Operation.{Complete, InProgress}
 import models.Task
 import models.maintain.Tasks
 import play.api.libs.json._
@@ -101,8 +101,8 @@ class MaintainTaskListController @Inject()(
 			service.modifyTask(request.internalId, identifier, Task.OtherIndividuals, Complete).map(Ok(_))
 	}
 
-	def resetAssets(identifier: String): Action[AnyContent] = authAction.async {
+	def inProgressAssets(identifier: String): Action[AnyContent] = authAction.async {
 		implicit request =>
-			service.modifyTask(request.internalId, identifier, Task.Assets, Reset).map(Ok(_))
+			service.modifyTask(request.internalId, identifier, Task.Assets, InProgress).map(Ok(_))
 	}
 }

--- a/app/models/Operation.scala
+++ b/app/models/Operation.scala
@@ -20,11 +20,11 @@ object Operation {
   sealed trait Operation {
     val value : Boolean = this match {
       case Complete => true
-      case Reset => false
+      case InProgress => false
     }
   }
 
   case object Complete extends Operation
-  case object Reset extends Operation
+  case object InProgress extends Operation
 
 }

--- a/app/models/Operation.scala
+++ b/app/models/Operation.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+object Operation {
+  sealed trait Operation {
+    val value : Boolean = this match {
+      case Complete => true
+      case Reset => false
+    }
+  }
+
+  case object Complete extends Operation
+  case object Reset extends Operation
+
+}

--- a/app/models/Task.scala
+++ b/app/models/Task.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+object Task {
+  sealed trait Task
+
+  case object TrustDetails extends Task
+
+  case object Assets extends Task
+
+  case object TaxLiability extends Task
+
+  case object Trustees extends Task
+
+  case object Beneficiaries extends Task
+
+  case object Settlors extends Task
+
+  case object Protectors extends Task
+
+  case object OtherIndividuals extends Task
+}

--- a/app/models/maintain/TaskCache.scala
+++ b/app/models/maintain/TaskCache.scala
@@ -23,7 +23,7 @@ import models.MongoDateTimeFormats
 
 case class TaskCache(internalId: String,
                      id: String,
-                     task: Task,
+                     task: Tasks,
                      lastUpdated: LocalDateTime = LocalDateTime.now)
 
 
@@ -35,7 +35,7 @@ object TaskCache extends MongoDateTimeFormats {
     (
       (__ \ "internalId").read[String] and
         (__ \ "id").read[String] and
-        (__ \ "task").read[Task] and
+        (__ \ "task").read[Tasks] and
         (__ \ "lastUpdated").read(localDateTimeRead)
       ) (TaskCache.apply _)
   }
@@ -44,7 +44,7 @@ object TaskCache extends MongoDateTimeFormats {
     (
       (__ \ "internalId").write[String] and
         (__ \ "id").write[String] and
-        (__ \ "task").write[Task] and
+        (__ \ "task").write[Tasks] and
         (__ \ "lastUpdated").write(localDateTimeWrite)
       ) (unlift(TaskCache.unapply))
   }

--- a/app/models/maintain/Tasks.scala
+++ b/app/models/maintain/Tasks.scala
@@ -18,18 +18,18 @@ package models.maintain
 
 import play.api.libs.json.{Format, Json}
 
-case class Task(trustDetails: Boolean,
-                assets: Boolean,
-                taxLiability: Boolean,
-                trustees: Boolean,
-                beneficiaries: Boolean,
-                settlors: Boolean,
-                protectors: Boolean,
-                other: Boolean)
+case class Tasks(trustDetails: Boolean,
+                 assets: Boolean,
+                 taxLiability: Boolean,
+                 trustees: Boolean,
+                 beneficiaries: Boolean,
+                 settlors: Boolean,
+                 protectors: Boolean,
+                 other: Boolean)
 
-object Task {
+object Tasks {
 
-  def apply(): Task = Task(
+  def apply(): Tasks = Tasks(
     trustDetails = false,
     assets = false,
     taxLiability = false,
@@ -40,6 +40,6 @@ object Task {
     other = false
   )
 
-  implicit val formats: Format[Task] = Json.format[Task]
+  implicit val formats: Format[Tasks] = Json.format[Tasks]
 
 }

--- a/app/repositories/TasksRepository.scala
+++ b/app/repositories/TasksRepository.scala
@@ -16,7 +16,7 @@
 
 package repositories
 
-import models.maintain.{Task, TaskCache}
+import models.maintain.{Tasks, TaskCache}
 import play.api.Configuration
 import play.api.libs.json.{JsObject, Json, OWrites}
 import play.modules.reactivemongo.ReactiveMongoApi
@@ -91,7 +91,7 @@ class TasksRepository @Inject()(override val mongo: ReactiveMongoApi,
       )
   }
 
-  def set(internalId: String, identifier: String, updated: Task): Future[Boolean] = {
+  def set(internalId: String, identifier: String, updated: Tasks): Future[Boolean] = {
 
     val insertCache = TaskCache(internalId, identifier, updated)
 
@@ -107,6 +107,6 @@ class TasksRepository @Inject()(override val mongo: ReactiveMongoApi,
   }
 
   def reset(internalId: String, identifier: String): Future[Boolean] = {
-    set(internalId, identifier, Task())
+    set(internalId, identifier, Tasks())
   }
 }

--- a/app/services/TasksService.scala
+++ b/app/services/TasksService.scala
@@ -16,29 +16,52 @@
 
 package services
 
-import javax.inject.{Inject, Singleton}
-import models.maintain.Task
+import models.Operation.Operation
+import models.Task
+import models.Task.Task
+import models.maintain.Tasks
+import play.api.libs.json.{JsValue, Json}
 import repositories.TasksRepository
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton()
 class TasksService @Inject()(tasksRepository: TasksRepository)  {
 
-  def get(internalId: String, identifier: String): Future[Task] = {
+  def get(internalId: String, identifier: String): Future[Tasks] = {
     tasksRepository.get(internalId, identifier) map {
       case Some(cache) => cache.task
-      case None => Task()
+      case None => Tasks()
     }
   }
 
-  def set(internalId: String, identifier: String, updated: Task): Future[Task] = {
+  def set(internalId: String, identifier: String, updated: Tasks): Future[Tasks] = {
     tasksRepository.set(internalId, identifier, updated).map(_ => updated)
   }
 
   def reset(internalId: String, identifier: String): Future[Boolean] = {
     tasksRepository.reset(internalId, identifier)
+  }
+
+  def modifyTask(internalId: String, identifier: String, update: Task, operation: Operation): Future[JsValue] = {
+    for {
+      tasks <- get(internalId, identifier)
+      updatedTasks <- Future.successful {
+        update match {
+          case Task.TrustDetails => tasks.copy(trustDetails = operation.value)
+          case Task.Assets => tasks.copy(assets = operation.value)
+          case Task.TaxLiability => tasks.copy(taxLiability = operation.value)
+          case Task.Trustees => tasks.copy(trustees = operation.value)
+          case Task.Beneficiaries => tasks.copy(beneficiaries = operation.value)
+          case Task.Protectors => tasks.copy(protectors = operation.value)
+          case Task.Settlors => tasks.copy(settlors = operation.value)
+          case Task.OtherIndividuals => tasks.copy(other = operation.value)
+        }
+      }
+      savedTasks <- set(internalId, identifier, updatedTasks)
+    } yield Json.toJson(savedTasks)
   }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -15,5 +15,7 @@ POST       /maintain/tasks/protectors/:identifier           controllers.Maintain
 POST       /maintain/tasks/settlors/:identifier             controllers.MaintainTaskListController.completeSettlors(identifier: String)
 POST       /maintain/tasks/others/:identifier               controllers.MaintainTaskListController.completeOtherIndividuals(identifier: String)
 
+POST       /maintain/tasks/reset/assets/:identifier               controllers.MaintainTaskListController.resetAssets(identifier: String)
+
 GET        /features/:flagName             controllers.FeatureFlagController.get(flagName: FeatureFlagName)
 PUT        /features/:flagName             controllers.FeatureFlagController.put(flagName: FeatureFlagName)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -15,7 +15,7 @@ POST       /maintain/tasks/protectors/:identifier           controllers.Maintain
 POST       /maintain/tasks/settlors/:identifier             controllers.MaintainTaskListController.completeSettlors(identifier: String)
 POST       /maintain/tasks/others/:identifier               controllers.MaintainTaskListController.completeOtherIndividuals(identifier: String)
 
-POST       /maintain/tasks/reset/assets/:identifier               controllers.MaintainTaskListController.resetAssets(identifier: String)
+POST       /maintain/tasks/reset/assets/:identifier               controllers.MaintainTaskListController.inProgressAssets(identifier: String)
 
 GET        /features/:flagName             controllers.FeatureFlagController.get(flagName: FeatureFlagName)
 PUT        /features/:flagName             controllers.FeatureFlagController.put(flagName: FeatureFlagName)

--- a/it/repositories/TasksRepositorySpec.scala
+++ b/it/repositories/TasksRepositorySpec.scala
@@ -1,6 +1,6 @@
 package repositories
 
-import models.maintain.Task
+import models.maintain.Tasks
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.Helpers._
@@ -37,7 +37,7 @@ class TasksRepositorySpec extends FreeSpec with MustMatchers
 
           val repository = application.injector.instanceOf[TasksRepository]
 
-          val task = Task(
+          val task = Tasks(
             trustDetails = false,
             assets = false,
             taxLiability = false,
@@ -68,7 +68,7 @@ class TasksRepositorySpec extends FreeSpec with MustMatchers
 
           val repository = application.injector.instanceOf[TasksRepository]
 
-          val allTasksComplete = Task(
+          val allTasksComplete = Tasks(
             trustDetails = true,
             assets = true,
             taxLiability = true,
@@ -79,7 +79,7 @@ class TasksRepositorySpec extends FreeSpec with MustMatchers
             other = true
           )
 
-          val allTasksIncomplete = Task(
+          val allTasksIncomplete = Tasks(
             trustDetails = false,
             assets = false,
             taxLiability = false,

--- a/test/controllers/MaintainTaskListControllerSpec.scala
+++ b/test/controllers/MaintainTaskListControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import base.BaseSpec
-import models.Operation.Complete
+import models.Operation.{Complete, Reset}
 import models.Task
 import models.Task.TrustDetails
 import org.mockito.Matchers.any
@@ -438,39 +438,40 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
   }
 
-//  "invoking POST /maintain/task/trust-details/reset" - {
-//    "must return Ok and reset the specified task" in {
-//      val request = FakeRequest(POST, routes.MaintainTaskListController.resetTrustDetails("utr").url)
-//
-//      val tasksCompletedSoFar = Tasks(
-//        trustDetails = true,
-//        assets = false,
-//        taxLiability = false,
-//        trustees = false,
-//        beneficiaries = true,
-//        settlors = false,
-//        other = false,
-//        protectors = false
-//      )
-//
-//      val updatedTasks = Tasks(
-//        trustDetails = false,
-//        assets = false,
-//        taxLiability = false,
-//        trustees = false,
-//        beneficiaries = true,
-//        settlors = false,
-//        other = false,
-//        protectors = false
-//      )
-//
-//      when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
-//      when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
-//
-//      val result = route(application, request).value
-//
-//      status(result) mustBe Status.OK
-//      contentAsJson(result) mustBe Json.toJson(updatedTasks)
-//    }
-//  }
+  "invoking POST /maintain/task/assets/reset" - {
+    "must return Ok and reset the specified task" in {
+      val request = FakeRequest(POST, routes.MaintainTaskListController.resetAssets("utr").url)
+
+      val tasksCompletedSoFar = Tasks(
+        trustDetails = false,
+        assets = true,
+        taxLiability = false,
+        trustees = false,
+        beneficiaries = true,
+        settlors = false,
+        other = false,
+        protectors = false
+      )
+
+      val updatedTasks = Tasks(
+        trustDetails = false,
+        assets = false,
+        taxLiability = false,
+        trustees = false,
+        beneficiaries = true,
+        settlors = false,
+        other = false,
+        protectors = false
+      )
+
+      when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
+      when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Assets), Matchers.eq(Reset))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
+
+      val result = route(application, request).value
+
+      status(result) mustBe Status.OK
+      contentAsJson(result) mustBe Json.toJson(updatedTasks)
+    }
+  }
 }

--- a/test/controllers/MaintainTaskListControllerSpec.scala
+++ b/test/controllers/MaintainTaskListControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import base.BaseSpec
-import models.Operation.{Complete, Reset}
+import models.Operation.{Complete, InProgress}
 import models.Task
 import models.Task.TrustDetails
 import org.mockito.Matchers.any
@@ -438,9 +438,9 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
   }
 
-  "invoking POST /maintain/task/assets/reset" - {
+  "invoking POST /maintain/task/reset/assets" - {
     "must return Ok and reset the specified task" in {
-      val request = FakeRequest(POST, routes.MaintainTaskListController.resetAssets("utr").url)
+      val request = FakeRequest(POST, routes.MaintainTaskListController.inProgressAssets("utr").url)
 
       val tasksCompletedSoFar = Tasks(
         trustDetails = false,
@@ -466,7 +466,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
-      when(service.modifyTask(any(), any(), Matchers.eq(Task.Assets), Matchers.eq(Reset))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Assets), Matchers.eq(InProgress))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 

--- a/test/controllers/MaintainTaskListControllerSpec.scala
+++ b/test/controllers/MaintainTaskListControllerSpec.scala
@@ -17,8 +17,11 @@
 package controllers
 
 import base.BaseSpec
+import models.Operation.Complete
+import models.Task
+import models.Task.TrustDetails
 import org.mockito.Matchers.any
-import org.mockito.Mockito
+import org.mockito.{Matchers, Mockito}
 import org.mockito.Mockito._
 import play.api.Application
 import play.api.http.Status
@@ -26,7 +29,7 @@ import play.api.inject.bind
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import models.maintain.Task
+import models.maintain.Tasks
 import services.TasksService
 
 import scala.concurrent.Future
@@ -49,7 +52,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return OK and the completed Tasks" in {
       val request = FakeRequest(GET, routes.MaintainTaskListController.get("utr").url)
 
-      val tasks = Task(
+      val tasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -73,7 +76,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
   "invoking POST /maintain/tasks" - {
 
     "must return OK and the completed Tasks for valid tasks" in {
-      val tasks = Task(
+      val tasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -128,7 +131,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeTrustDetails("utr").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -139,7 +142,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = true,
         assets = false,
         taxLiability = false,
@@ -152,6 +155,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(TrustDetails), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -166,7 +170,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeAssets("urn").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -177,7 +181,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = true,
         taxLiability = false,
@@ -190,6 +194,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Assets), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -204,7 +209,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeTaxLiability("urn").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -215,7 +220,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = true,
@@ -228,6 +233,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.TaxLiability), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -242,7 +248,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeTrustees("utr").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -253,7 +259,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -266,6 +272,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Trustees), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -280,7 +287,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeBeneficiaries("utr").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -291,7 +298,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -304,6 +311,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Beneficiaries), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -318,7 +326,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeProtectors("utr").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -329,7 +337,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -342,6 +350,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Protectors), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -356,7 +365,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeSettlors("utr").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -367,7 +376,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -380,6 +389,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.Settlors), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -394,7 +404,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     "must return Ok and the completed tasks" in {
       val request = FakeRequest(POST, routes.MaintainTaskListController.completeOtherIndividuals("utr").url)
 
-      val tasksCompletedSoFar = Task(
+      val tasksCompletedSoFar = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -405,7 +415,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
         protectors = false
       )
 
-      val updatedTasks = Task(
+      val updatedTasks = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,
@@ -418,6 +428,7 @@ class MaintainTaskListControllerSpec extends BaseSpec {
 
       when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
       when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+      when(service.modifyTask(any(), any(), Matchers.eq(Task.OtherIndividuals), Matchers.eq(Complete))).thenReturn(Future.successful(Json.toJson(updatedTasks)))
 
       val result = route(application, request).value
 
@@ -426,4 +437,40 @@ class MaintainTaskListControllerSpec extends BaseSpec {
     }
 
   }
+
+//  "invoking POST /maintain/task/trust-details/reset" - {
+//    "must return Ok and reset the specified task" in {
+//      val request = FakeRequest(POST, routes.MaintainTaskListController.resetTrustDetails("utr").url)
+//
+//      val tasksCompletedSoFar = Tasks(
+//        trustDetails = true,
+//        assets = false,
+//        taxLiability = false,
+//        trustees = false,
+//        beneficiaries = true,
+//        settlors = false,
+//        other = false,
+//        protectors = false
+//      )
+//
+//      val updatedTasks = Tasks(
+//        trustDetails = false,
+//        assets = false,
+//        taxLiability = false,
+//        trustees = false,
+//        beneficiaries = true,
+//        settlors = false,
+//        other = false,
+//        protectors = false
+//      )
+//
+//      when(service.get(any(), any())).thenReturn(Future.successful(tasksCompletedSoFar))
+//      when(service.set(any(), any(), any())).thenReturn(Future.successful(updatedTasks))
+//
+//      val result = route(application, request).value
+//
+//      status(result) mustBe Status.OK
+//      contentAsJson(result) mustBe Json.toJson(updatedTasks)
+//    }
+//  }
 }

--- a/test/services/TasksServiceSpec.scala
+++ b/test/services/TasksServiceSpec.scala
@@ -24,7 +24,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito._
 import play.api.Application
 import play.api.inject.bind
-import models.maintain.{Task, TaskCache}
+import models.maintain.{Tasks, TaskCache}
 import repositories.TasksRepository
 
 import scala.concurrent.Future
@@ -47,7 +47,7 @@ class TasksServiceSpec extends BaseSpec {
 
     "must return a Task from the repository if there is one for the given internal id and utr" in {
 
-      val task = Task()
+      val task = Tasks()
 
       val taskCache = TaskCache(
         "internalId",
@@ -64,7 +64,7 @@ class TasksServiceSpec extends BaseSpec {
     }
 
     "must return a Task from the repository if there is not one for the given internal id and utr" in {
-      val task = Task()
+      val task = Tasks()
 
       when(repository.get(mEq("internalId"), mEq("utr"))).thenReturn(Future.successful(None))
 
@@ -78,7 +78,7 @@ class TasksServiceSpec extends BaseSpec {
 
     "must set an updated Task" in {
 
-      val task = Task(
+      val task = Tasks(
         trustDetails = false,
         assets = false,
         taxLiability = false,


### PR DESCRIPTION
Endpoint to support setting the assets journey to in progress when the user removes all the assets on a NTT -> TT migration.